### PR TITLE
Primary goal (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ by a PR so other fellow can try it.
 | 757024 | Germán Garcés| [report.md](https://github.com/fntkg/lab6-microservices/blob/work/report.md)     | |       |
 | 721520 | Sergio García-Campero Hernández | [solution.md](https://github.com/SergioGCH/lab6-microservices/blob/test/solution.md)     | |       |
 | 779691 | [Tomás Pelayo](https://github.com/Tomenos18/lab6-microservices)|[Report](https://github.com/Tomenos18/lab6-microservices/blob/test/report.md)| | |
+| 847512 | Mauricio Andrés Rosso| [report](https://github.com/MauriRosso/lab6-microservices/blob/work/report.md)     | |       |

--- a/accounts/src/main/resources/application.yml
+++ b/accounts/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
 
 # HTTP Server
 server:
-  port: 2222   # HTTP (Tomcat) port
+  port: 4444   # HTTP (Tomcat) port
 
 # Discovery Server Access
 eureka:

--- a/accounts/src/main/resources/application.yml
+++ b/accounts/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
 
 # HTTP Server
 server:
-  port: 4444   # HTTP (Tomcat) port
+  port: 2222   # HTTP (Tomcat) port
 
 # Discovery Server Access
 eureka:


### PR DESCRIPTION
### Activity 1: The two services accounts (2222) and web are running and registered
<hr>
First of all, we have to run the Eureka server, running the following command:

`./gradlew :registration:bootRun`

After that, we launch the account service in the same way:

`./gradlew :accounts:bootRun`

![Captura_1(Accounts2222)](https://user-images.githubusercontent.com/26725798/149407757-4c151b18-9960-4a25-bc5c-863dfd384102.PNG)

Then, we launch the web service:

`./gradlew :web:bootRun`

![Captura_2(Web3333)](https://user-images.githubusercontent.com/26725798/149408689-8c4e14c4-b303-42f7-8563-1b6baa424a34.PNG)

### Activity 2: The service registration service has these two services registered
<hr>

Now, we can see the two services registered in Eureka dashboard:

![Captura_3(Eureka)](https://user-images.githubusercontent.com/26725798/149408542-0b527bf5-7031-4f26-951e-40de8afb6514.PNG)

### Activity 3: A second accounts service instance is started and will use the port 4444. This second accounts (4444) is also registered
<hr>

To use the port 4444, we have to modify the `accounts/src/main/resources/application.yml` file, and change the port 2222 instead of 4444.

![Captura_4(Codigo_4444)](https://user-images.githubusercontent.com/26725798/149409235-4257954a-4711-4df2-adc1-56f23368bc29.PNG)

After that, we run the second account service and register on Eureka server. 

![Captura_5(Accounts4444)](https://user-images.githubusercontent.com/26725798/149409410-7ae599b0-f701-4728-97dc-bdf7bee6808a.PNG)

Now, we can  see three services in the dashboard:

![Captura_6(Eureka_3_Servicios)](https://user-images.githubusercontent.com/26725798/149409552-1039bb05-3d05-44e1-803a-5fe4d48f6477.PNG)

### Activity 4: What happens when you kill the service accounts (2222) and do requests to web?
<hr>

If service accounts with port :2222 is killed, we can see that it will be removed from the Eureka dashboard, as the follow screenshot show:

![Captura_7(Eureka_Kill2222)](https://user-images.githubusercontent.com/26725798/149409833-19e914ec-194a-4c4d-aef3-93cdc5ac67a7.PNG)

When suddenly we try to do a request to the killed service, shows to us a webpage that is no longer available. Once Eureka detects this, it starts redirecting to accounts with port :4444.

![Captura_8(Eureka_web_info)](https://user-images.githubusercontent.com/26725798/149410474-362a358d-e2fb-4d19-b544-907f42c7990e.PNG)

This happens because web service asks Eureka server the real location of the URL **https://ACCOUNTS-SERVICE** and Eureka answers with the location of the second accounts service rightly.
