### PR TITLE
lab 6 gift done

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Some ideas for obtaining a :gift: if you are the first that:
 
 * [Circuit breaker for the requests from web to accounts that avoids a 500 error](https://spring.io/guides/gs/circuit-breaker/)
   .
-* [API gateway for web and registration](https://github.com/spring-attic/gs-routing-and-filtering).
+* ~[API gateway for web and registration](https://github.com/spring-attic/gs-routing-and-filtering)~ implemented by [ZenithGD](https://github.com/ZenithGD/lab6-microservices/tree/work).
 * [Centralized configuration for all services](https://github.com/spring-attic/gs-routing-and-filtering).
 * [Dockerize the three services](https://spring.io/guides/topicals/spring-boot-docker).
 * [Docker compose with scale by command line](https://thepracticaldeveloper.com/dockerize-spring-boot/).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ by a PR so other fellow can try it.
 
 | User name                                                            | NIA | Report                                                                               | Score                             |
 |----------------------------------------------------------------------|-----|--------------------------------------------------------------------------------------|-----------------------------------|
-| [ZenithGD](https://github.com/ZenithGD/lab6-microservices/tree/work) | 795306 | [REPORT.md](https://github.com/ZenithGD/lab6-microservices/blob/work/docs/report.md) | Plan to implement **API gateway** |
+| [ZenithGD](https://github.com/ZenithGD/lab6-microservices/tree/work) | 795306 | [REPORT.md](https://github.com/ZenithGD/lab6-microservices/blob/work/docs/report.md) | **API gateway** 🎁 |
 | [pikanachi](https://github.com/pikanachi/lab6-microservices/tree/work) | 610720 | [REPORT.md](https://github.com/pikanachi/lab6-microservices/blob/work/docs/REPORT.md) |
 | [celiia01](https://github.com/celiia01/lab6-microservices/tree/work) | 796685 | [REPORT.md](https://github.com/celiia01/lab6-microservices/blob/work/docs/REPORT.md) |   |
 | [Ernesting](https://github.com/Ernesting/lab6-microservices/tree/work) | 798799 | [REPORT.md](https://github.com/Ernesting/lab6-microservices/blob/work/docs/REPORT.md) | |


### PR DESCRIPTION
# Implement a gateway for registration and web service

I implemented the gateway for both services with Spring Cloud Gateway, with 3 filters:
- First one will route `/registration/` to the Eureka discovery service. For example, `localhost:4444/registration` will be routed to `localhost/1111`.
  > **Warning**: Don't forget to include the trailing slash! 
- Second one will map routes that start with `/eureka` to the discovery service, but won't remove the prefix. This allows routing of every resource requests for the registration service, since otherwise some resources wouldn't be served and the web page wouldn't work as expected. For example, `localhost:4444/eureka/wso.css` will be routed to `localhost:1111/eureka/wso.css`
- Last one is a fallback for every other route, which will be sent to the web service. This solves the same problem as the second route, since adding a `/web` filter instead of allowing everything else wouldn't serve the static files from the web page. For example, `localhost:4444/accounts/123456789` will be routed to `localhost:4444/accounts/123456789`
> **Note** Current link on the problem statement points to [GS Routing and Filtering](https://github.com/spring-attic/gs-routing-and-filtering), which has been discontinued by Spring's devs. I used Spring Cloud Gateway instead, following some of the ideas found in [this](https://www.baeldung.com/spring-cloud-gateway) article.

I also implemented some tests to ensure that the gateway is filtering and routing everything correctly.
![image](https://user-images.githubusercontent.com/37598162/209416726-626b38f3-7bfb-4efb-9567-94ce8fba49f2.png)
